### PR TITLE
Change dp to px converter to existing helper

### DIFF
--- a/ahbottomnavigation/src/main/java/com/aurelhubert/ahbottomnavigation/AHBottomNavigation.java
+++ b/ahbottomnavigation/src/main/java/com/aurelhubert/ahbottomnavigation/AHBottomNavigation.java
@@ -205,10 +205,6 @@ public class AHBottomNavigation extends FrameLayout {
 		super.onRestoreInstanceState(state);
 	}
 
-	public static float pxFromDp(final Context context, final float dp) {
-		return dp * context.getResources().getDisplayMetrics().density;
-	}
-
 
 	/////////////
 	// PRIVATE //

--- a/ahbottomnavigation/src/main/java/com/aurelhubert/ahbottomnavigation/AHBottomNavigation.java
+++ b/ahbottomnavigation/src/main/java/com/aurelhubert/ahbottomnavigation/AHBottomNavigation.java
@@ -219,8 +219,8 @@ public class AHBottomNavigation extends FrameLayout {
         activePaddingTop = (int) resources.getDimension(R.dimen.bottom_navigation_margin_top_active);
         activeMarginTop = (int) resources.getDimension(R.dimen.bottom_navigation_small_margin_top_active);
         widthDifference = resources.getDimension(R.dimen.bottom_navigation_small_selected_width_difference);
-        defaultIconHeight = resources.getDimensionPixelSize(R.dimen.bottom_navigation_icon);
-        defaultIconWidth = resources.getDimensionPixelSize(R.dimen.bottom_navigation_icon);
+        defaultIconHeight = resources.getDimension(R.dimen.bottom_navigation_icon);
+        defaultIconWidth = resources.getDimension(R.dimen.bottom_navigation_icon);
 
         // Icon colors
         fill(iconActiveColor, MAX_ITEMS, null);

--- a/ahbottomnavigation/src/main/java/com/aurelhubert/ahbottomnavigation/AHBottomNavigation.java
+++ b/ahbottomnavigation/src/main/java/com/aurelhubert/ahbottomnavigation/AHBottomNavigation.java
@@ -205,6 +205,11 @@ public class AHBottomNavigation extends FrameLayout {
 		super.onRestoreInstanceState(state);
 	}
 
+	public static float pxFromDp(final Context context, final float dp) {
+		return dp * context.getResources().getDisplayMetrics().density;
+	}
+
+
 	/////////////
 	// PRIVATE //
 	/////////////
@@ -219,8 +224,8 @@ public class AHBottomNavigation extends FrameLayout {
         activePaddingTop = (int) resources.getDimension(R.dimen.bottom_navigation_margin_top_active);
         activeMarginTop = (int) resources.getDimension(R.dimen.bottom_navigation_small_margin_top_active);
         widthDifference = resources.getDimension(R.dimen.bottom_navigation_small_selected_width_difference);
-        defaultIconHeight = resources.getDimension(R.dimen.bottom_navigation_icon);
-        defaultIconWidth = resources.getDimension(R.dimen.bottom_navigation_icon);
+        defaultIconHeight = dpToPx(R.dimen.bottom_navigation_icon);
+        defaultIconWidth = dpToPx(R.dimen.bottom_navigation_icon);
 
         // Icon colors
         fill(iconActiveColor, MAX_ITEMS, null);


### PR DESCRIPTION
I kept getting this error, which crashed react-native app after loading bundle: 
"android.content.res.Resources$NotFoundException: Resource ID #0x7f070052 type #0x10 is not valid"
 when using getDimensionPixelSize to convert. This fixes the crash