### PR TITLE
Add nullability check for the notification text color

### DIFF
--- a/ahbottomnavigation/src/main/java/com/aurelhubert/ahbottomnavigation/notification/AHNotification.java
+++ b/ahbottomnavigation/src/main/java/com/aurelhubert/ahbottomnavigation/notification/AHNotification.java
@@ -128,7 +128,8 @@ public class AHNotification implements Parcelable {
             return this;
         }
 
-        public Builder setTextColor(@ColorInt int textColor) {
+        public Builder setTextColor(@ColorInt Integer textColor) {
+            if (textColor == null) return this;
             this.textColor = textColor;
             return this;
         }


### PR DESCRIPTION
In order to add a property in rn-navigation to set the `badgeTextColor` we need to handle null case similar to `setBackgroundColor`